### PR TITLE
fix: export central credentials for setup-java

### DIFF
--- a/.github/workflows/wc_java_maven_central.yml
+++ b/.github/workflows/wc_java_maven_central.yml
@@ -142,6 +142,10 @@ jobs:
 
       - name: "☕ Setup Java [${{ steps.java_info.outputs.java_version }}] [Central + Maven Cache]"
         uses: actions/setup-java@v5
+        env:
+          CENTRAL_USER: ${{ secrets.CENTRAL_USER }}
+          CENTRAL_PASS: ${{ secrets.CENTRAL_PASS }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         with:
           java-version: ${{ steps.java_info.outputs.java_version }}
           distribution: "temurin"


### PR DESCRIPTION
## Why
The reusable Central workflow validates the Sonatype secrets, but the  step did not export , , or  into that step.  expects the credential names to reference environment variables, so the generated Maven settings could end up with empty Central credentials and fail with 401.

## What changed
- export , , and  into the Central  step

## Effect
- the generated Maven settings now actually receive the Sonatype credentials used for Portal upload