### PR TITLE
fix: pass central credentials into deploy step

### DIFF
--- a/.github/workflows/wc_java_maven_central.yml
+++ b/.github/workflows/wc_java_maven_central.yml
@@ -241,6 +241,8 @@ jobs:
         shell: bash
         env:
           CMD: ${{ steps.java_info.outputs.cmd }}
+          CENTRAL_USER: ${{ secrets.CENTRAL_USER }}
+          CENTRAL_PASS: ${{ secrets.CENTRAL_PASS }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Why
Comparing against the older working `wc_java_build.yml` shows one more important difference: the actual `mvn deploy` step exported `CENTRAL_USER` and `CENTRAL_PASS` in its environment.

The split Central workflow did not. If the generated Maven settings resolve credentials through `env.CENTRAL_USER` / `env.CENTRAL_PASS`, the deploy step still needs those environment variables present at runtime.

## What changed
- export `CENTRAL_USER` and `CENTRAL_PASS` into the `Publish To Maven Central` step

## Effect
- aligns the new split workflow with the old working Central publish behavior
